### PR TITLE
fix cornjob

### DIFF
--- a/matomo.yaml
+++ b/matomo.yaml
@@ -258,11 +258,11 @@ objects:
         template:
           spec:
             containers:
-            - command:
-              - bash
+            - args:
+              - /bin/sh
               - -c
-              - tar cf - --one-file-system -C /usr/src/matomo . | tar xf - --no-overwrite-dir
-                && php -f /var/www/html/console core:archive
+              # true; is a workaround solution
+              - true; /usr/local/bin/php /var/www/html/console core:archive
               image: matomo
               imagePullPolicy: Always
               name: cron


### PR DESCRIPTION
Using `args` instead of `command` will execute entrypoint which copies matomo source code to `/var/www/html/`